### PR TITLE
Table updates

### DIFF
--- a/application/templates/breakdown-by-authority.html
+++ b/application/templates/breakdown-by-authority.html
@@ -55,7 +55,7 @@
                                 <td class="govuk-table__cell result-cell successful">Yes</td>
                                 {% else %}
                                 <td class="govuk-table__cell result-cell error">No
-                                    <span class="test-result-link">(<a href="{{ url_for('frontend.result_details_for_authority', local_authority_id=item.organisation) }}"><span class="govuk-visually-hidden">See { item.organisation | map_la_code_to_name }} register validation </span>Results</a>)</span>
+{#                                    <span class="test-result-link">(<a href="{{ url_for('frontend.result_details_for_authority', local_authority_id=item.organisation) }}"><span class="govuk-visually-hidden">See { item.organisation | map_la_code_to_name }} register validation </span>Results</a>)</span>#}
                                 </td>
                                 {% endif %}
                               {%- else -%}

--- a/application/templates/breakdown-by-authority.html
+++ b/application/templates/breakdown-by-authority.html
@@ -18,7 +18,7 @@
 <table class="govuk-table results-table">
 	<thead class="govuk-table__head">
 		<tr class="govuk-table__row validation-result-row">
-            <th class="govuk-table__header center-align-cell">Date of validation</th>
+            <th class="govuk-table__header">Date of validation</th>
             <th class="govuk-table__header center-align-cell">Register downloadable</th>
 			<th class="govuk-table__header center-align-cell">Register in CSV format</th>
 			<th class="govuk-table__header center-align-cell">CSV headers correct</th>
@@ -26,30 +26,57 @@
 		</tr>
 	</thead>
 	<tbody class="govuk-table__body">
-		{% for result in data.results %}
-            <tr class="govuk-table__row {{ 'govuk-table__row--no-border' if development_mode == 'true' }}">
-                <td class="govuk-table__cell result-cell">{{ result.date }}</td>
-                {% set statusCode = result.validated.statusCode|string %}
-                <td class="govuk-table__cell result-cell {{ 'successful' if statusCode == '200' else 'error' }}">{{ 'Yes' if statusCode == '200' else 'No' }}</td>
-                {% set isCSV = result.validated.isCsv|string %}
-                <td class="govuk-table__cell result-cell {{ 'successful' if isCSV == 'True' else 'error' }}">{{ 'Yes' if isCSV == 'True' else 'No' }}</td>
-                {% set hasHeaders = result.validated.hasRequiredHeaders|string %}
-                <td class="govuk-table__cell result-cell {{ 'successful' if hasHeaders== 'True' else 'error' }}">{{ 'Yes' if hasHeaders == 'True' else 'No' }}</td>
-                {% set isValid = result.validated.isValid|string %}
-                <td class="govuk-table__cell result-cell {{ 'successful' if isValid == 'True' else 'error' }}">{{ 'Yes' if isValid == 'True' else 'No' }}</td>
-            </tr>
-            {% if development_mode == 'true' %}
-                <tr class="govuk-table__row">
-                    <td class="govuk-table__cell" colspan="6">
-                        <div class="dev-output-row">
-                            <span class="dev-output-title">Output:</span>
-                            <div class="dev-output">{{ result }}</div>
-                        </div>
+	    {% for item in data.results %}
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                    {{ item.date }}
+                </td>
+                {%- if not item.validated %}
+                    <td class="govuk-table__cell result-cell--not-available center-align-cell" colspan="4">
+                        <span class="validation-result-not-available">No results available</span>
                     </td>
-                </tr>
-		    {% endif %}
-		{% endfor %}
+                {% else %}
 
+                    {% if item.validated.statusCode == 200 %}
+                        <td class="govuk-table__cell result-cell successful">Yes
+                            <span class="test-result-link">(<a href="{{ item['register-url'] if item['register-url']}}">Download<span class="govuk-visually-hidden"> {{ item.organisation | map_la_code_to_name }} brownfield land register</span></a>)</span>
+                        </td>
+
+                        {%- set isCSV = item.validated.isCsv|string %}
+                        <td class="govuk-table__cell result-cell {{ 'successful' if isCSV == 'True' else 'error' }}">{{ 'Yes' if isCSV == 'True' else 'No' }}</td>
+
+                        {%- if isCSV == 'True' -%}
+
+                            {% set hasHeaders = item.validated.hasRequiredHeaders|string %}
+                            <td class="govuk-table__cell result-cell {{ 'successful' if hasHeaders== 'True' else 'error' }}">{{ 'Yes' if hasHeaders == 'True' else 'No' }}</td>
+
+                            {%- if hasHeaders == 'True' -%}
+                                {% if item.validated.isValid|string == 'True' %}
+                                <td class="govuk-table__cell result-cell successful">Yes</td>
+                                {% else %}
+                                <td class="govuk-table__cell result-cell error">No
+                                    <span class="test-result-link">(<a href="{{ url_for('frontend.result_details_for_authority', local_authority_id=item.organisation) }}"><span class="govuk-visually-hidden">See { item.organisation | map_la_code_to_name }} register validation </span>Results</a>)</span>
+                                </td>
+                                {% endif %}
+                              {%- else -%}
+                                <td class="govuk-table__cell result-cell error">-</td>
+                              {%- endif -%}
+
+                        {%- else -%}
+                            <td class="govuk-table__cell result-cell error">-</td>
+                            <td class="govuk-table__cell result-cell error">-</td>
+                        {%- endif -%}
+
+                    {% else %}
+                        <td class="govuk-table__cell result-cell error">No</td>
+                        <td class="govuk-table__cell result-cell error">-</td>
+                        <td class="govuk-table__cell result-cell error">-</td>
+                        <td class="govuk-table__cell result-cell error">-</td>
+                    {% endif %}
+
+                {% endif %}
+            </tr>
+		{% endfor %}
 	</tbody>
 </table>
 

--- a/application/templates/breakdown.html
+++ b/application/templates/breakdown.html
@@ -15,7 +15,7 @@
 <table class="govuk-table results-table">
 	<thead class="govuk-table__head">
 		<tr class="govuk-table__row validation-result-row">
-			<th class="govuk-table__header" colspan="2">Local Authority</th>
+			<th class="govuk-table__header" colspan="2">Planning Authority</th>
 			<th class="govuk-table__header center-align-cell">Register downloadable</th>
 			<th class="govuk-table__header center-align-cell">Register in CSV format</th>
 			<th class="govuk-table__header center-align-cell">CSV headers correct</th>

--- a/application/templates/breakdown.html
+++ b/application/templates/breakdown.html
@@ -25,20 +25,9 @@
 	<tbody class="govuk-table__body">
 		{% for item in data['Items'] %}
 		<tr class="govuk-table__row {{ 'govuk-table__row--no-border' if development_mode == 'true' }}">
-			<td class="govuk-table__cell" colspan="2">{{ item.organisation | map_la_code_to_name }}
-                {% if development_mode == 'true' %}
-                    <p>Other pages to link to</p>
-                    <ul>
-                        <li><a href="{{ url_for('frontend.local_authority_results', local_authority_id=item.organisation, development_mode=development_mode) }}">
-                            History of validations for this council
-                            </a>
-                        </li>
-                        <li><a href="{{ url_for('frontend.result_details_for_authority', local_authority_id=item.organisation) }}">
-                            Latest validation result details
-                            </a>
-                        </li>
-                    </ul>
-                {% endif %}
+			<td class="govuk-table__cell" colspan="2">
+                {{ item.organisation | map_la_code_to_name }}
+                <p class="govuk-body-s"><a href="{{ url_for('frontend.local_authority_results', local_authority_id=item.organisation, development_mode=development_mode) }}">See past results</a></p>
             </td>
 			{%- if not item.validated %}
                 <td class="govuk-table__cell result-cell--not-available center-align-cell" colspan="4">

--- a/application/templates/overview.html
+++ b/application/templates/overview.html
@@ -10,7 +10,7 @@
 
 <div class="data-item govuk-!-margin-bottom-6">
 	<span class="data-item__number govuk-!-font-size-80">{{ data.summary.total }}</span>
-	<p class="govuk-body govuk-!-font-size-36">Local authorities checked</p>
+	<p class="govuk-body govuk-!-font-size-36">Planning authorities checked</p>
 </div>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-9">
@@ -40,7 +40,7 @@
 	</div>
 </div>
 
-<a href="{{ url_for('frontend.breakdown') }}" class="govuk-link govuk-!-font-size-24">See full breakdown by Local Authority</a>
+<a href="{{ url_for('frontend.breakdown') }}" class="govuk-link govuk-!-font-size-24">See full breakdown by Planning Authority</a>
 
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 


### PR DESCRIPTION
@colmjude eh up one more for you fix up  :)

I added link to history page, ripped off markup from breakdown template for history. I know I don't need to remind you but feel free to move it somewhere else.

Note that link to results detail (which is present on breakdown page, and goes to placeholder) is not available from history page removed as I'm not sure we'll get that at the moment.

I'm told results detail will be coming soon, but don't have a url yet for it. When it comes then we can replace placeholder page.