### PR TITLE
Add required db

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -2,3 +2,4 @@ FLASK_ENV=development
 FLASK_CONFIG=config.DevelopmentConfig
 FLASK_APP=application.wsgi:app
 SECRET_KEY=replaceinprod
+DATABASE_URL=postgresql://localhost/brownfield_status

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Install front end build tool (gulp)
 
     npm install && gulp scss
 
+Create a db to store cached results
+
+    createdb brownfield_status
+
+Run migrations to set up db
+
+    flask db upgrade
+
 Run the app
 
     flask run


### PR DESCRIPTION
The db used for caching the results was removed from the .flaskenv file in commit d8bf08dd

Not sure if that was accidental or not but it causes an error to be thrown when I run `flask run` so I've added it back in and also added instructions to the readme.